### PR TITLE
remove spread operator that fails on edge 18

### DIFF
--- a/src/JsonCSV.vue
+++ b/src/JsonCSV.vue
@@ -167,11 +167,10 @@
           return
         }
 
-        let csv = PapaParse.unparse(dataExport, {
+        let csv = PapaParse.unparse(dataExport, Object.assign({
           delimiter: this.delimiter,
           encoding: this.encoding,
-          ...this.advancedOptions
-        })
+        }, this.advancedOptions));
         if (this.separatorExcel) {
           csv = 'SEP=' + this.delimiter + '\r\n' + csv
         }


### PR DESCRIPTION
Babel is not transpiling spread operator with preset-env, I tried to use the babel spread plugin without success. As it's used just in one place, I changed the spread to Object.assign that works on edge.