### PR TITLE
Vendor Bundle Improvement (lodash) - Bundle size over 568kb to 50kb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ fabric.properties
 
 node_modules/
 
+dist/
+yarn-error.log
+

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   ],
   "dependencies": {
     "file-saver": "^2.0.2",
-    "lodash": "^4.17.15",
+    "lodash.mapkeys": "^4.6.0",
+    "lodash.pick": "^4.4.0",
+    "lodash.pickby": "^4.6.0",
     "papaparse": "^5.1.1",
     "vue": "^2.6.11"
   },

--- a/src/JsonCSV.vue
+++ b/src/JsonCSV.vue
@@ -1,195 +1,215 @@
 <template>
-    <div
-            :id="idName"
-            @click="generate"
-    >
-        <slot>
-            Download {{name}}
-        </slot>
-    </div>
+  <div :id="idName" @click="generate">
+    <slot>Download {{name}}</slot>
+  </div>
 </template>
 
 <script>
-  import _ from 'lodash'
-  import { saveAs } from 'file-saver';
+import mapKeys from "lodash.mapkeys";
+import pickBy from "lodash.pickby";
+import pick from "lodash.pick";
 
-  import PapaParse from 'papaparse'
+import { saveAs } from "file-saver";
+import { unparse } from "papaparse";
 
-  export default {
-    name: 'JsonCSV',
-    props: {
-      /**
-       * Json to download
-       */
-      data: {
-        type: Array,
-        required: true
-      },
-      /**
-       * fields inside the Json Object that you want to export
-       * if no given, all the properties in the Json are exported
-       * Can either be an array or a function
-       */
-      fields: {
-        required: false
-      },
-      /**
-       * filename to export, default: data.csv
-       */
-      name: {
-        type: String,
-        default: 'data.csv'
-      },
-      /**
-       * Delimiter for the CSV file
-       */
-      delimiter: {
-        type: String,
-        default: ',',
-        required: false
-      },
-      /**
-       * Should the module add SEP={delimiter}
-       *
-       * Useful for opening file with Excel
-       */
-      separatorExcel: {
-        type: Boolean,
-        default: false
-      },
-      /**
-       * What will be the encoding of the file
-       */
-      encoding: {
-        type: String,
-        default: 'utf-8'
-      },
-      /**
-       * Advanced options for Papaparse that is used to export to CSV
-       */
-      advancedOptions: {
-        type: Object,
-        default: () => {
-        }
-      },
-      /**
-       * Labels for columns
-       *
-       * Object or function
-       */
-      labels: {
-        required: false
-      },
-      /**
-       * Used only for testing purposes
-       */
-      testing: {
-        required: false,
-        default: false
-      }
+export const isType = (value, type) => typeof value === type;
+
+export default {
+  name: "JsonCSV",
+  props: {
+    /**
+     * Json to download
+     */
+    data: {
+      type: Array,
+      required: true
     },
-    computed: {
-      // unique identifier
-      idName () {
-        const now = new Date().getTime()
-        return 'export_' + now
-      },
-      exportableData () {
-        const filteredData = this.cleaningData()
-        if (!filteredData.length) {
-          return null
-        }
-
-        return filteredData
-      }
+    /**
+     * fields inside the Json Object that you want to export
+     * if no given, all the properties in the Json are exported
+     * Can either be an array or a function
+     */
+    fields: {
+      required: false
     },
-    methods: {
-      labelsFunctionGenerator () {
+    /**
+     * filename to export, default: data.csv
+     */
+    name: {
+      type: String,
+      default: "data.csv"
+    },
+    /**
+     * Delimiter for the CSV file
+     */
+    delimiter: {
+      type: String,
+      default: ",",
+      required: false
+    },
+    /**
+     * Should the module add SEP={delimiter}
+     *
+     * Useful for opening file with Excel
+     */
+    separatorExcel: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * What will be the encoding of the file
+     */
+    encoding: {
+      type: String,
+      default: "utf-8"
+    },
+    /**
+     * Advanced options for Papaparse that is used to export to CSV
+     */
+    advancedOptions: {
+      type: Object,
+      default: () => {}
+    },
+    /**
+     * Labels for columns
+     *
+     * Object or function
+     */
+    labels: {
+      required: false
+    },
+    /**
+     * Used only for testing purposes
+     */
+    testing: {
+      required: false,
+      default: false
+    }
+  },
+  computed: {
+    // unique identifier
+    idName() {
+      const now = new Date().getTime();
+      return "export_" + now;
+    },
+    exportableData() {
+      const filteredData = this.cleaningData();
+      if (!filteredData.length) {
+        return null;
+      }
 
-        if(!_.isUndefined(this.labels) && !_.isFunction(this.labels) && !_.isObject(this.labels)) {
-          throw new Error('Labels needs to be a function(value,key) or object.')
-        }
+      return filteredData;
+    }
+  },
+  methods: {
+    labelsFunctionGenerator() {
+      if (
+        !isType(this.labels, "undefined") &&
+        !isType(this.labels, "function") &&
+        !isType(this.labels, "object")
+      ) {
+        throw new Error("Labels needs to be a function(value,key) or object.");
+      }
 
-        if (_.isFunction(this.labels)) {
-          return (item) => {
-            let mapKeys = _.mapKeys(item, this.labels)
-            return mapKeys
-          }
-        }
+      if (isType(this.labels, "function")) {
+        return item => {
+          let _mapKeys = mapKeys(item, this.labels);
+          return _mapKeys;
+        };
+      }
 
-        if (_.isObject(this.labels)) {
-          return (item) => {
-            return _.mapKeys(item, (item, key) => {
-              return this.labels[key] || key
-            })
-          }
-        }
+      if (isType(this.labels, "object")) {
+        return item => {
+          return mapKeys(item, (item, key) => {
+            return this.labels[key] || key;
+          });
+        };
+      }
 
-        return (item) => item
-      },
+      return item => item;
+    },
 
-      fieldsFunctionGenerator () {
-        if(!_.isUndefined(this.fields) && !_.isFunction(this.fields) && !_.isObject(this.fields) && !_.isArray(this.fields)) {
-          throw new Error('Fields needs to be a function(value,key) or array.')
-        }
+    fieldsFunctionGenerator() {
+      if (
+        !isType(this.fields, "undefined") &&
+        !isType(this.fields, "function") &&
+        !isType(this.fields, "object") &&
+        !Array.isArray(this.fields)
+      ) {
+        throw new Error("Fields needs to be a function(value,key) or array.");
+      }
 
-        if (_.isFunction(this.fields) || (_.isObject(this.fields) && !_.isArray(this.fields))) {
-          return (item) => {
-            return _.pickBy(item, this.fields)
-          }
-        }
+      if (
+        isType(this.fields, "function") ||
+        (isType(this.fields, "object") && !Array.isArray(this.fields))
+      ) {
+        return item => {
+          return pickBy(item, this.fields);
+        };
+      }
 
-        if (_.isArray(this.fields)) {
-          return (item) => {
-            return _.pick(item, this.fields)
-          }
-        }
-        return (item) => item
-      },
+      if (Array.isArray(this.fields)) {
+        return item => {
+          return pick(item, this.fields);
+        };
+      }
+      return item => item;
+    },
 
-      cleaningData () {
-        if (_.isUndefined(this.fields) && _.isUndefined(this.labels)) {
-          return this.data
-        }
+    cleaningData() {
+      if (
+        isType(this.fields, "undefined") &&
+        isType(this.labels, "undefined")
+      ) {
+        return this.data;
+      }
 
-        const labels = this.labelsFunctionGenerator()
-        const fields = this.fieldsFunctionGenerator()
+      const labels = this.labelsFunctionGenerator();
+      const fields = this.fieldsFunctionGenerator();
 
-        return _.map(this.data, (item) => labels(fields(item)))
-      },
+      return this.data.map(item => labels(fields(item)));
+    },
 
-      generate () {
-        this.$emit('export-started')
-        const dataExport = this.exportableData
+    generate() {
+      this.$emit("export-started");
+      const dataExport = this.exportableData;
 
-        if (!dataExport) {
-          console.error('No data to export')
-          return
-        }
+      if (!dataExport) {
+        console.error("No data to export");
+        return;
+      }
 
-        let csv = PapaParse.unparse(dataExport, Object.assign({
-          delimiter: this.delimiter,
-          encoding: this.encoding,
-        }, this.advancedOptions));
-        if (this.separatorExcel) {
-          csv = 'SEP=' + this.delimiter + '\r\n' + csv
-        }
-        //Add BOM when UTF-8
-        if(this.encoding === "utf-8") {
-            csv = "\ufeff" + csv
-        }
-        this.$emit('export-finished')
-        if (!this.testing) {
-          let blob = new Blob([csv], {type: "application/csv;charset=" + this.encoding})
-          saveAs(blob, this.name)
-        }
+      let csv = unparse(
+        dataExport,
+        Object.assign(
+          {
+            delimiter: this.delimiter,
+            encoding: this.encoding
+          },
+          this.advancedOptions
+        )
+      );
+      if (this.separatorExcel) {
+        csv = "SEP=" + this.delimiter + "\r\n" + csv;
+      }
+      //Add BOM when UTF-8
+      if (this.encoding === "utf-8") {
+        csv = "\ufeff" + csv;
+      }
+      this.$emit("export-finished");
+      if (!this.testing) {
+        let blob = new Blob([csv], {
+          type: "application/csvcharset=" + this.encoding
+        });
+        saveAs(blob, this.name);
       }
     }
   }
+};
 </script>
 
 <style scoped>
-    div {
-        display: inline;
-    }
+div {
+  display: inline;
+}
 </style>

--- a/tests/JsonCSV.test.js
+++ b/tests/JsonCSV.test.js
@@ -1,6 +1,5 @@
-import {mount} from '@vue/test-utils'
-import Component from '../src/JsonCSV'
-import _ from 'lodash'
+import { mount } from '@vue/test-utils'
+import Component, { isType } from '../src/JsonCSV'
 
 describe('Component', () => {
   test('is a Vue instance', () => {
@@ -16,11 +15,11 @@ describe('Component', () => {
     const wrapper = mount(Component, {
       propsData: {
         data: [
-          {'id': 1, 'fname': 'Jesse', 'lname': 'Simmons', 'date': '2016-10-15 13:43:27', 'gender': 'Male'},
-          {'id': 2, 'fname': 'John', 'lname': 'Jacobs', 'date': '2016-12-15 06:00:53', 'gender': 'Male'},
-          {'id': 3, 'fname': 'Tina', 'lname': 'Gilbert', 'date': '2016-04-26 06:26:28', 'gender': 'Female'},
-          {'id': 4, 'fname': 'Clarence', 'lname': 'Flores', 'date': '2016-04-10 10:28:46', 'gender': 'Male'},
-          {'id': 5, 'fname': 'Anne', 'lname': 'Lee', 'date': '2016-12-06 14:38:38', 'gender': 'Female'}
+          { id: 1, fname: 'Jesse', lname: 'Simmons', date: '2016-10-15 13:43:27', gender: 'Male' },
+          { id: 2, fname: 'John', lname: 'Jacobs', date: '2016-12-15 06:00:53', gender: 'Male' },
+          { id: 3, fname: 'Tina', lname: 'Gilbert', date: '2016-04-26 06:26:28', gender: 'Female' },
+          { id: 4, fname: 'Clarence', lname: 'Flores', date: '2016-04-10 10:28:46', gender: 'Male' },
+          { id: 5, fname: 'Anne', lname: 'Lee', date: '2016-12-06 14:38:38', gender: 'Female' }
         ],
         fields: ['fname', 'lname']
       }
@@ -41,14 +40,14 @@ describe('Component', () => {
       const wrapper = mount(Component, {
         propsData: {
           data: [
-            {'id': 1, 'fname': 'Jesse', 'lname': 'Simmons', 'date': '2016-10-15 13:43:27', 'gender': 'Male'},
-            {'id': 2, 'fname': 'John', 'lname': 'Jacobs', 'date': '2016-12-15 06:00:53', 'gender': 'Male'},
-            {'id': 3, 'fname': 'Tina', 'lname': 'Gilbert', 'date': '2016-04-26 06:26:28', 'gender': 'Female'},
-            {'id': 4, 'fname': 'Clarence', 'lname': 'Flores', 'date': '2016-04-10 10:28:46', 'gender': 'Male'},
-            {'id': 5, 'fname': 'Anne', 'lname': 'Lee', 'date': '2016-12-06 14:38:38', 'gender': 'Female'}
+            { id: 1, fname: 'Jesse', lname: 'Simmons', date: '2016-10-15 13:43:27', gender: 'Male' },
+            { id: 2, fname: 'John', lname: 'Jacobs', date: '2016-12-15 06:00:53', gender: 'Male' },
+            { id: 3, fname: 'Tina', lname: 'Gilbert', date: '2016-04-26 06:26:28', gender: 'Female' },
+            { id: 4, fname: 'Clarence', lname: 'Flores', date: '2016-04-10 10:28:46', gender: 'Male' },
+            { id: 5, fname: 'Anne', lname: 'Lee', date: '2016-12-06 14:38:38', gender: 'Female' }
           ],
           labels: (value, key) => {
-            if (_.endsWith(key, 'name')) {
+            if (key.endsWith('name')) {
               return key.replace('name', 'Name')
             }
             return key
@@ -69,11 +68,11 @@ describe('Component', () => {
       const wrapper = mount(Component, {
         propsData: {
           data: [
-            {'id': 1, 'fname': 'Jesse', 'lname': 'Simmons', 'date': '2016-10-15 13:43:27', 'gender': 'Male'},
-            {'id': 2, 'fname': 'John', 'lname': 'Jacobs', 'date': '2016-12-15 06:00:53', 'gender': 'Male'},
-            {'id': 3, 'fname': 'Tina', 'lname': 'Gilbert', 'date': '2016-04-26 06:26:28', 'gender': 'Female'},
-            {'id': 4, 'fname': 'Clarence', 'lname': 'Flores', 'date': '2016-04-10 10:28:46', 'gender': 'Male'},
-            {'id': 5, 'fname': 'Anne', 'lname': 'Lee', 'date': '2016-12-06 14:38:38', 'gender': 'Female'}
+            { id: 1, fname: 'Jesse', lname: 'Simmons', date: '2016-10-15 13:43:27', gender: 'Male' },
+            { id: 2, fname: 'John', lname: 'Jacobs', date: '2016-12-15 06:00:53', gender: 'Male' },
+            { id: 3, fname: 'Tina', lname: 'Gilbert', date: '2016-04-26 06:26:28', gender: 'Female' },
+            { id: 4, fname: 'Clarence', lname: 'Flores', date: '2016-04-10 10:28:46', gender: 'Male' },
+            { id: 5, fname: 'Anne', lname: 'Lee', date: '2016-12-06 14:38:38', gender: 'Female' }
           ],
           labels: {
             fname: 'First Name',
@@ -97,11 +96,11 @@ describe('Component', () => {
       const wrapper = mount(Component, {
         propsData: {
           data: [
-            {'id': 1, 'fname': 'Jesse', 'lname': 'Simmons', 'date': '2016-10-15 13:43:27', 'gender': 'Male'},
-            {'id': 2, 'fname': 'John', 'lname': 'Jacobs', 'date': '2016-12-15 06:00:53', 'gender': 'Male'},
-            {'id': 3, 'fname': 'Tina', 'lname': 'Gilbert', 'date': '2016-04-26 06:26:28', 'gender': 'Female'},
-            {'id': 4, 'fname': 'Clarence', 'lname': 'Flores', 'date': '2016-04-10 10:28:46', 'gender': 'Male'},
-            {'id': 5, 'fname': 'Anne', 'lname': 'Lee', 'date': '2016-12-06 14:38:38', 'gender': 'Female'}
+            { id: 1, fname: 'Jesse', lname: 'Simmons', date: '2016-10-15 13:43:27', gender: 'Male' },
+            { id: 2, fname: 'John', lname: 'Jacobs', date: '2016-12-15 06:00:53', gender: 'Male' },
+            { id: 3, fname: 'Tina', lname: 'Gilbert', date: '2016-04-26 06:26:28', gender: 'Female' },
+            { id: 4, fname: 'Clarence', lname: 'Flores', date: '2016-04-10 10:28:46', gender: 'Male' },
+            { id: 5, fname: 'Anne', lname: 'Lee', date: '2016-12-06 14:38:38', gender: 'Female' }
           ],
           fields: ['fname', 'lname']
         }
@@ -120,13 +119,13 @@ describe('Component', () => {
       const wrapper = mount(Component, {
         propsData: {
           data: [
-            {'id': 1, 'fname': 'Jesse', 'lname': 'Simmons', 'date': '2016-10-15 13:43:27', 'gender': 'Male'},
-            {'id': 2, 'fname': 'John', 'lname': 'Jacobs', 'date': '2016-12-15 06:00:53', 'gender': 'Male'},
-            {'id': 3, 'fname': 'Tina', 'lname': 'Gilbert', 'date': '2016-04-26 06:26:28', 'gender': 'Female'},
-            {'id': 4, 'fname': 'Clarence', 'lname': 'Flores', 'date': '2016-04-10 10:28:46', 'gender': 'Male'},
-            {'id': 5, 'fname': 'Anne', 'lname': 'Lee', 'date': '2016-12-06 14:38:38', 'gender': 'Female'}
+            { id: 1, fname: 'Jesse', lname: 'Simmons', date: '2016-10-15 13:43:27', gender: 'Male' },
+            { id: 2, fname: 'John', lname: 'Jacobs', date: '2016-12-15 06:00:53', gender: 'Male' },
+            { id: 3, fname: 'Tina', lname: 'Gilbert', date: '2016-04-26 06:26:28', gender: 'Female' },
+            { id: 4, fname: 'Clarence', lname: 'Flores', date: '2016-04-10 10:28:46', gender: 'Male' },
+            { id: 5, fname: 'Anne', lname: 'Lee', date: '2016-12-06 14:38:38', gender: 'Female' }
           ],
-          fields: (value, key) => _.endsWith(key, 'name')
+          fields: (value, key) => key.endsWith('name')
         }
       })
       const vm = wrapper.vm
@@ -145,7 +144,7 @@ describe('Component', () => {
     const wrapper = mount(Component, {
       propsData: {
         data: [
-          {'id': 1, 'fname': 'Jesse', 'lname': 'Simmons', 'date': '2016-10-15 13:43:27', 'gender': 'Male'}
+          { id: 1, fname: 'Jesse', lname: 'Simmons', date: '2016-10-15 13:43:27', gender: 'Male' }
         ],
         testing: true
       }
@@ -156,5 +155,14 @@ describe('Component', () => {
 
     expect(wrapper.emitted()['export-started']).toBeTruthy()
     expect(wrapper.emitted()['export-finished']).toBeTruthy()
+  })
+})
+
+describe('Utils', () => {
+  test('isType', () => {
+    expect(isType(function () { }, 'function')).toBe(true)
+    expect(isType({}, 'object')).toBe(true)
+    expect(isType('csv', 'string')).toBe(true)
+    expect(isType(undefined, 'undefined')).toBe(true)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5292,7 +5292,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5531,11 +5531,6 @@ detect-indent@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -7942,7 +7937,7 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -8065,7 +8060,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -9741,11 +9736,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -9754,32 +9744,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -9846,6 +9814,11 @@ lodash.map@^4.5.1:
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
 
+lodash.mapkeys@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mapkeys/-/lodash.mapkeys-4.6.0.tgz#df2cfa231d7c57c7a8ad003abdad5d73d3ea5195"
+  integrity sha1-3yz6Ix18V8eorQA6va1dc9PqUZU=
+
 lodash.mapvalues@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
@@ -9861,15 +9834,15 @@ lodash.merge@^4.6.1:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.pickby@4.6.0:
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
+
+lodash.pickby@4.6.0, lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
   integrity sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -10581,15 +10554,6 @@ neat-csv@^2.1.0:
     get-stream "^2.1.0"
     into-stream "^2.0.0"
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -10733,22 +10697,6 @@ node-notifier@^5.4.0, node-notifier@^5.4.2:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
-
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 node-releases@^1.1.44:
   version "1.1.45"
@@ -10904,7 +10852,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.12, npm-packlist@^1.1.6, npm-packlist@^1.4.7:
+npm-packlist@^1.1.12, npm-packlist@^1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
   integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
@@ -11090,7 +11038,7 @@ npm@^6.10.3:
     worker-farm "^1.7.0"
     write-file-atomic "^2.4.3"
 
-npmlog@^4.0.2, npmlog@^4.1.2, npmlog@~4.1.2:
+npmlog@^4.1.2, npmlog@~4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -12785,7 +12733,7 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -14528,7 +14476,7 @@ tar-stream@^1.5.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.13, tar@^4.4.2:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.13:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
## WHAT

Due to how the `imports` from `lodash` were done the build was not being tree-shook properly, making the package exceed the threshold of `244 KiB`.  By `import _ from 'lodash'`, it executes a file scan which make `apps` that install   `vue-json-csv` forcefully have to download the full package at production mode because its internal per dependencies. 

![Screen Shot 2020-03-28 at 8 07 42 PM](https://user-images.githubusercontent.com/17863803/77836832-f9688680-712f-11ea-83c9-4015512507cd.png)

![Screen Shot 2020-03-28 at 6 36 09 PM](https://user-images.githubusercontent.com/17863803/77836713-de494700-712e-11ea-94f1-2034ae5b5c25.png)

![Screen Shot 2020-03-28 at 6 36 00 PM](https://user-images.githubusercontent.com/17863803/77836716-ec976300-712e-11ea-9696-770a973fe1c8.png)

## HOW 

1 -  Change some utilities `isUndefined, isFunction, isArray, IsObject, map` for natives:
`const isType = (value, type) => typeof value === type`

implementation

`isType(this.labels, "function")`
`isType(this.labels, "undefined")`
`isType(this.labels, "object")`
`Array.isArray(this.labels)`
`this.data.map((value, index) => {...})`

2 -  Remove the package `lodash` and installed the standalone functions:

`import mapKeys from lodash.mapkeys`
`...`
`lodash.mapkeys`
`lodash.pick`
`lodash.pickBy`

3 - Destructed the `unparse` from  `papaparse`

`import { unparse } from papaparse`

## RESULT

**Reduced the package size by 70% & now it can be tree-shaken properly by whoever decides to install this library** 

![Screen Shot 2020-03-28 at 8 19 26 PM](https://user-images.githubusercontent.com/17863803/77836945-71837c00-7131-11ea-8753-642c80f2aafb.png)

## TEST

![Screen Shot 2020-03-28 at 8 40 30 PM](https://user-images.githubusercontent.com/17863803/77837193-5fefa380-7134-11ea-98a1-28d0ba3036cc.png)

