### PR TITLE
fix(types): add types entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "main": "dist/vue-json-csv.common.js",
   "unpkg": "dist/vue-json-csv.umd.min.js",
+  "types": "dist/JsonCSV.vue.d.ts",
   "files": [
     "dist/",
     "src/",


### PR DESCRIPTION
The package is successfully generating types; however, there is no entry in the `package.json` to tell consuming packages where the types are located.

```md
Could not find a declaration file for module 'vue-json-csv'.
```

This PR should resolve #222.